### PR TITLE
Up version for fabric8 plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <awaitility.version>3.1.0</awaitility.version>
     <rest-assured.version>3.1.0</rest-assured.version>
     <openjdk18-openshift.version>1.3</openjdk18-openshift.version>
+    <fabric8-maven-plugin.version>4.0.0</fabric8-maven-plugin.version>
     <fabric8.generator.from>
       registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:${openjdk18-openshift.version}
     </fabric8.generator.from>
@@ -212,6 +213,7 @@
           <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>fabric8-maven-plugin</artifactId>
+            <version>${fabric8-maven-plugin.version}</version>
             <executions>
               <execution>
                 <id>fmp</id>


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

If try to deploy this sample on OpenShift 4 by `mvn clean fabric8:deploy -Popenshift`, I see  an error:
```log
[INFO] F8: spring-boot: Using Docker image registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift:1.3 as base / builder
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:52 min
[INFO] Finished at: 2019-11-07T13:33:50Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal io.fabric8:fabric8-maven-plugin:3.5.40:build (fmp) on project rest-http: Execution fmp of goal io.fabric8:fabric8-maven-plugin:3.5.40:build failed: No <dockerHost> given, no DOCKER_HOST environment variable, no read/writable '/var/run/docker.sock' or '//./pipe/docker_engine' and no external provider like Docker machine configured -> [Help 1]
[ERROR] 
```
This PR sets **4.0.0** version for **fabric8-maven-plugin** to make it possible to deploy this sample on OpenShift 4. It also works for OpenShift 3.