### PR TITLE
bump dekorate 2.11.5 and removed default maven settings on dekorate OCP

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build Project using Dekorate
         run: |
           oc new-project dekorate
-          ./run_tests_with_dekorate_in_ocp.sh
+          ./run_tests_with_dekorate_in_ocp.sh -s .github/mvn-settings.xml
       - name: Delete Project using Dekorate
         run: oc delete project dekorate
       - name: Clean folder

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Alternativelly, tests can be executed against a specific Spring Boot or Dekorate
 version as a `-D<variable property name>=value` parameter. For instance overriding both the Spring Boot and the Dekorate versions using their corresponding version properties is done the following way:
 
 ```bash
-./run_tests_with_dekorate.sh -Dspring-boot.version=2.7.3 -Ddekorate.version=2.11.1
+./run_tests_with_dekorate_in_ocp.sh -Dspring-boot.version=2.7.3 -Ddekorate.version=2.11.1
 ```
 
 ## Running Tests on OpenShift using S2i from Source

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
 
     <spring-boot.version>2.7.2</spring-boot.version>
-    <dekorate.version>2.11.4</dekorate.version>
+    <dekorate.version>2.11.5</dekorate.version>
     <resteasy-spring-boot-starter.version>3.9.4.Final</resteasy-spring-boot-starter.version>
 
     <!-- Overriden from Spring Boot -->

--- a/run_tests_with_dekorate_in_ocp.sh
+++ b/run_tests_with_dekorate_in_ocp.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 # Run Tests
-eval "./mvnw -s .github/mvn-settings.xml clean verify -Popenshift,openshift-it $@"
+eval "./mvnw clean verify -Popenshift,openshift-it $@"


### PR DESCRIPTION
* bump dekorate 2.11.5
* removed Maven Settings from defaulting on the `run_tests_with_dekorate_in_ocp.sh` script

`Automated from ansible update-examples-upstream-versions-playbook`